### PR TITLE
fixed back to manage roles button + made button reigstered

### DIFF
--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import Image from "next/image";
 import arrowLeft from "@/assets/icons/arrow-left.svg";
 import EventNotFoundModal from "@/components/common/EventNotFoundModal";
+import { prisma } from "@/lib/prisma";
 
 export default async function EventDetailsPage(props: {
   params: { id: string };
@@ -25,6 +26,25 @@ export default async function EventDetailsPage(props: {
     ]);
 
     const user = await getCurrentUser();
+    let registeredPositionIds = new Set<string>();
+
+    if (user?.id && user.role !== UserRole.ADMIN) {
+      const [signups, waitlists] = await Promise.all([
+        prisma.eventSignup.findMany({
+          where: { userId: user.id, eventId },
+          select: { positionId: true },
+        }),
+        prisma.eventWaitlist.findMany({
+          where: { userId: user.id, position: { eventId } },
+          select: { positionId: true },
+        }),
+      ]);
+
+      registeredPositionIds = new Set([
+        ...signups.map((s) => s.positionId),
+        ...waitlists.map((w) => w.positionId),
+      ]);
+    }
 
     if (!event) {
       return <EventNotFoundModal />;
@@ -184,6 +204,7 @@ export default async function EventDetailsPage(props: {
                     totalSpots={item.totalSlots}
                     positionId={item.id}
                     streetAddress={location}
+                    isRegistered={registeredPositionIds.has(item.id)}
                   />
                 );
               }

--- a/src/components/AdminVolunteerProfileView.tsx
+++ b/src/components/AdminVolunteerProfileView.tsx
@@ -197,7 +197,7 @@ export default function AdminVolunteerProfileView({
         <div className="rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
           <p className="text-lg text-gray-700">Volunteer profile not found.</p>
           <button
-            onClick={() => router.push("/admin/manage")}
+            onClick={() => router.push("/admin/manage/roles")}
             className="mt-4 rounded-lg bg-bcp-blue px-4 py-2 text-white"
           >
             Back to Manage Roles
@@ -210,7 +210,7 @@ export default function AdminVolunteerProfileView({
   return (
     <main className="min-h-screen p-8">
       <div className="mt-[40px] ml-[120px]">
-        <Link href="/admin/manage" className="text-bcp-blue hover:underline">
+        <Link href="/admin/manage/roles" className="text-bcp-blue hover:underline">
           Back to Manage Roles
         </Link>
       </div>
@@ -317,7 +317,7 @@ export default function AdminVolunteerProfileView({
 
         <div className="flex justify-center gap-4 mt-[30.82px]">
           <button
-            onClick={() => router.push("/admin/manage")}
+            onClick={() => router.push("/admin/manage/roles")}
             className="h-[44px] w-[140px] rounded-lg bg-white text-black hover:bg-gray-300"
           >
             <div className="text-[16px]">Back to roles</div>

--- a/src/components/common/buttons/RegisterButton.tsx
+++ b/src/components/common/buttons/RegisterButton.tsx
@@ -7,22 +7,26 @@ interface RegisterButtonProps {
   positionId: string;
   disabled: boolean;
   isFull: boolean;
+  isRegistered: boolean;
 }
 
 export default function RegisterButton({
   positionId,
   disabled,
   isFull,
+  isRegistered,
 }: RegisterButtonProps) {
   const router = useRouter();
 
   return (
     <Button
-      label={isFull ? "Join Waitlist" : "Register"}
+      label={isRegistered ? "Registered" : isFull ? "Join Waitlist" : "Register"}
       disabled={disabled}
       onClick={() => router.push(`/register/${positionId}`)}
       altStyle={`mt-[12px] rounded font-medium flex items-center justify-center h-[40px] ${
-        isFull
+        isRegistered
+          ? "w-[120px] bg-gray-300 text-black hover:bg-gray-400 cursor-not-allowed"
+          : isFull
           ? "w-[120px] bg-gray-300 text-black hover:bg-gray-400"
           : "w-[94px] bg-light-bcp-blue text-white hover:bg-light-bcp-blue"
       }`}

--- a/src/components/common/tables/EventVolunteerTable.tsx
+++ b/src/components/common/tables/EventVolunteerTable.tsx
@@ -12,6 +12,7 @@ interface EventVolunteerTableProps {
   description: string;
   totalSpots: number;
   positionId: string;
+  isRegistered: boolean;
 }
 
 async function EventVolunteerTable(props: EventVolunteerTableProps) {
@@ -23,6 +24,7 @@ async function EventVolunteerTable(props: EventVolunteerTableProps) {
     description,
     totalSpots,
     positionId,
+    isRegistered,
   } = props;
 
   let volunteers: PublicUser[] = [];
@@ -96,9 +98,10 @@ async function EventVolunteerTable(props: EventVolunteerTableProps) {
 
         {!isPast && (
           <RegisterButton
-            disabled={isPast}
+            disabled={isPast || isRegistered}
             positionId={positionId}
             isFull={isFull}
+            isRegistered={isRegistered}
           />
         )}
       </div>


### PR DESCRIPTION
# Description

Fixed back to manage roles button so it takes you there
I also made the button say "Registered" when you register instead of "Register" 

Also about how Priyanka is on the waitlist for Tufts Giving Day v2 even though there is no one signed up, it's because she is already signed up for another position at the same time (same event if you wanna look). If we were to promote to signup, the times would overlap which is not allowed. 

## Issues

None

## Screenshots

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/509770e2-bd08-471f-9a1b-e6a0d4f6c61b" />

event signed up for:
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/2f60ab6b-2a9b-4086-9ddb-8d759b0cde95" />

event on waitlist for (same time):
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/28cb103f-4e54-42a5-9972-9d106397945a" />


## Test

go to manage roles, click a user, then click "Back to Manage Roles" button
register for an event and see the button change

## Possible Downsides

uh positions are supposed to be one day only now so i'm hoping tufts giving day v2 is an old event. (I just tried creating a new event with invalid times and it didn't work so we prob chilling).

## Additional Documentations

nah